### PR TITLE
ci: use matrix.ref in hitch.yml

### DIFF
--- a/.github/workflows/hitch.yml
+++ b/.github/workflows/hitch.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: varnish/hitch
-          ref: 1.8.0
+          ref: ${{ matrix.ref }}
           path: hitch
 
       # Do this before configuring so that it only detects the updated list of
@@ -92,7 +92,7 @@ jobs:
       - name: Configure and build hitch
         run: |
             cd $GITHUB_WORKSPACE/hitch/
-            patch -p1 < $GITHUB_WORKSPACE/osp/hitch/hitch_1.8.0.patch
+            patch -p1 < $GITHUB_WORKSPACE/osp/hitch/hitch_${{ matrix.ref }}.patch
             export SSL_CFLAGS="-I$GITHUB_WORKSPACE/build-dir/include/ -I$GITHUB_WORKSPACE/build-dir/include/wolfssl"
             export SSL_LIBS="-L$GITHUB_WORKSPACE/build-dir/lib -lwolfssl"
             ./bootstrap --with-wolfssl=$GITHUB_WORKSPACE/build-dir/ --prefix=$GITHUB_WORKSPACE/build-dir


### PR DESCRIPTION
Addresses @julek-wolfssl's [review comment](https://github.com/wolfSSL/wolfssl/pull/9897#discussion_r1986568195) on wolfSSL/wolfssl#9897:

> Use `matrix.ref` than hard coding the version everywhere.

This PR replaces the two remaining hardcoded `1.8.0` occurrences in `.github/workflows/hitch.yml` with `${{ matrix.ref }}`, leaving the matrix entry on line 47 as the single source of truth for the hitch version under test. Future version bumps become a one-line change.

Semantically identical for the current single-entry matrix (`1.8.0`).

Note: the patch-filename change implicitly contracts that wolfSSL/osp publishes a `hitch_<version>.patch` for each `ref` added to the matrix. Currently only `hitch_1.8.0.patch` is needed (per wolfSSL/osp#325), so no action required there until the matrix grows.

Merging this into `gh218` will unblock wolfSSL/wolfssl#9897, which in turn unblocks wolfSSL/osp#325 and resolves wolfSSL/osp#218.